### PR TITLE
TW-2634: add linkBuilder hook to MatrixLinkifyText

### DIFF
--- a/lib/src/matrix_linkify.dart
+++ b/lib/src/matrix_linkify.dart
@@ -4,6 +4,11 @@ import 'package:linkfy_text/src/enum.dart';
 import 'package:linkfy_text/src/model/link.dart';
 import 'package:linkfy_text/src/utils/matrix_regex.dart';
 
+/// Builder for rendering a detected link as a custom [InlineSpan].
+/// Receives the matched [Link] and the resolved [style]. Return `null` to
+/// fall back to the default [LinkTextSpan] behaviour.
+typedef LinkifyLinkBuilder = InlineSpan? Function(Link link, TextStyle? style);
+
 /// Matrix Linkify [text] containing urls, emails or hashtag
 class MatrixLinkifyText extends StatelessWidget {
   final String text;
@@ -14,6 +19,7 @@ class MatrixLinkifyText extends StatelessWidget {
   final ThemeData? themeData;
   final Function(Link)? onTapLink;
   final Function(TapDownDetails, Link)? onTapDownLink;
+  final LinkifyLinkBuilder? linkBuilder;
   final int? maxLines;
 
   const MatrixLinkifyText({
@@ -27,6 +33,7 @@ class MatrixLinkifyText extends StatelessWidget {
     this.themeData,
     this.onTapLink,
     this.onTapDownLink,
+    this.linkBuilder,
   }) : super(key: key);
 
   @override
@@ -40,6 +47,7 @@ class MatrixLinkifyText extends StatelessWidget {
         themeData: themeData,
         onTapLink: onTapLink,
         onTapDownLink: onTapDownLink,
+        linkBuilder: linkBuilder,
       ),
       textAlign: textAlign,
       maxLines: maxLines,
@@ -167,6 +175,7 @@ TextSpan LinkifyTextSpans({
   ThemeData? themeData,
   Function(Link)? onTapLink,
   Function(TapDownDetails, Link)? onTapDownLink,
+  LinkifyLinkBuilder? linkBuilder,
 }) {
   textStyle ??= themeData?.textTheme.bodyMedium;
   linkStyle ??= themeData?.textTheme.bodyMedium?.copyWith(
@@ -208,11 +217,17 @@ TextSpan LinkifyTextSpans({
         continue;
       }
       // add the link
+      final resolvedStyle = customLinkStyles?[link.type] ?? linkStyle;
+      final built = linkBuilder?.call(link, resolvedStyle);
+      if (built != null) {
+        spans.add(built);
+        continue;
+      }
       spans.add(
         LinkTextSpan(
           text: link.value,
           link: link,
-          style: customLinkStyles?[link.type] ?? linkStyle,
+          style: resolvedStyle,
           onTapLink: onTapLink,
           onTapDownLink: onTapDownLink,
         ),


### PR DESCRIPTION
## Summary

Expose a `linkBuilder` callback on `MatrixLinkifyText` and `LinkifyTextSpans` so consumers can render each detected link as a custom `InlineSpan` instead of the default `LinkTextSpan`. Opt-in, fully backward compatible.

## Motivation

The current API only allows tap handlers (`onTapLink`, `onTapDownLink`). Customising the *rendering* of a matched link (e.g. wrapping it in a different widget) is difficult.

Concrete use case in Twake Chat (`twake-on-matrix`): on Flutter web we want to overlay a real HTML `<a>` element on each detected URL so the browser shows its native right-click context menu (Open in new tab, Copy link address). The default `LinkTextSpan` is rendered to canvas and the browser sees no anchor element.

This mirrors the existing `linkBuilder` already exposed by `flutter_matrix_html` same name, same philosophy, same shape for ecosystem consistency.

## API

```dart
typedef LinkifyLinkBuilder = InlineSpan? Function(Link link, TextStyle? style);
```

- Called once per matched link, before the default `LinkTextSpan` is constructed
- Returns `null` to fall back to the default behaviour
- Receives the matched `Link` (`type`, `value`) and the resolved `TextStyle`

## Backward compatibility

`linkBuilder` is optional. When `null` (existing usage), behaviour is identical to before including the same `customLinkStyles?[link.type] ?? linkStyle` resolution (factored into a local variable, no behaviour change).

## Related

- Sibling PR: https://github.com/linagora/flutter_matrix_html/pull/26
- Consumer PR: https://github.com/linagora/twake-on-matrix/pull/3053